### PR TITLE
test: change s3-tests from single bucket to double buckets

### DIFF
--- a/docker/conf/client2.json
+++ b/docker/conf/client2.json
@@ -1,0 +1,16 @@
+{
+  "masterAddr": "192.168.0.11:17010,192.168.0.12:17010,192.168.0.13:17010",
+  "mountPoint": "/cfs/mnt2",
+  "volName": "s3test",
+  "owner": "ltptest",
+  "logDir": "/cfs/log",
+  "logLevel": "info",
+  "consulAddr": "http://192.168.0.101:8500",
+  "exporterPort": 9500,
+  "profPort": "17411",
+  "authenticate": false,
+  "ticketHost": "192.168.0.14:8080,192.168.0.15:8081,192.168.0.16:8082",
+  "enableHTTPS": "false",
+  "accessKey": "39bEF4RrAQgMj6RV",
+  "secretKey": "TRL6o3JL16YOqvZGIohBDFTHZDEcFsyd"
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -351,6 +351,7 @@ services:
             - ./bin:/cfs/bin:ro
             - ./conf/hosts:/etc/hosts:ro
             - ./conf/client.json:/cfs/conf/client.json
+            - ./conf/client2.json:/cfs/conf/client2.json
             - ${DiskPath:-./docker_data}/client/log:/cfs/log
             - ./script/run_test.sh:/cfs/script/start.sh
             - ./script/start_client.sh:/cfs/script/start_client.sh


### PR DESCRIPTION
We found a bug when muulti bucket were operated.
The s3-tests case now only support single bucket tests.
So I add a bucket named 's3test'.

Signed-off-by: wanglei469 <wanglei469@ke.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
